### PR TITLE
Fix missing dependencies

### DIFF
--- a/src/main/resources/assets/js/application/services/tdpInvestAuthService.js
+++ b/src/main/resources/assets/js/application/services/tdpInvestAuthService.js
@@ -1,5 +1,5 @@
 define(['angular','application/tdpInvestModule', 'application/services/tdpInvestBase64Service', 'ngCookies'], function(angular, tdpInvestModule) {
-    tdpInvestModule.service('tdpInvestAuthService', ['$cookieStore', '$http', '$rootScope', '$timeout', function($cookieStore, $http, $rootScope, tdpInvestBase64Service) {
+    tdpInvestModule.service('tdpInvestAuthService', ['$cookieStore', '$http', '$rootScope', 'tdpInvestBase64Service', function($cookieStore, $http, $rootScope, tdpInvestBase64Service) {
         var service = {};
 
         service.login = function(username, password) {


### PR DESCRIPTION
Wersja na masterze rzuca przy zakładaniu konta wyjątek niżej, bo po ostatnich zmianach nie dodaliśmy zależności. Teraz działa.

```
TypeError: Cannot read property 'encode' of undefined
    at Object.service.setCredentials (tdpInvestAuthService.js:19)
    at tdpInvestRegisterController.js:8
    at processQueue (angular.js:16170)
    at angular.js:16186
    at Scope.$eval (angular.js:17444)
    at Scope.$digest (angular.js:17257)
    at Scope.$apply (angular.js:17552)
    at done (angular.js:11697)
    at completeRequest (angular.js:11903)
    at XMLHttpRequest.requestLoaded (angular.js:11836)
```
